### PR TITLE
Fixed `token_path` updates when using atomic writes

### DIFF
--- a/module.go
+++ b/module.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -47,7 +48,9 @@ func (s *VaultStorage) Provision(ctx caddy.Context) error {
 			return err
 		}
 
-		err = watcher.Add(s.TokenPath)
+		// Watch the directory of the file, rather than just the
+		// individual file itself, to accommodate atomic file updates.
+		err = watcher.Add(filepath.Dir(s.TokenPath))
 		if err != nil {
 			return err
 		}
@@ -63,9 +66,11 @@ func (s *VaultStorage) Provision(ctx caddy.Context) error {
 						s.logger.Debug("Stopped token file watcher", zap.String("path", s.TokenPath))
 						return
 					}
-					if event.Has(fsnotify.Write) {
-						s.logger.Debug("Token file has been updated", zap.String("path", s.TokenPath))
-						s.LoadTokenFromFile()
+					if event.Name == s.TokenPath {
+						if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
+							s.logger.Debug("Token file has been updated", zap.String("path", s.TokenPath))
+							s.LoadTokenFromFile()
+						}
 					}
 				case err, ok := <-watcher.Errors:
 					if !ok {


### PR DESCRIPTION
Atomic writes are when a program creates a new temporary file next to the original file, writes contents into it, and then moves the temporary file to the location of the original file, replacing the original file.

The file watcher will continue to watch the old file node with the old contents and not the new file node with the new contents.

Many editors do this, but also Vault Agent when using its auto-auth feature with a [file sink] to issue and pass a token to this module.

fsnotify recommends watching the parent directory of a file and not the individual file in its [README.md] to reliably track both types of writes, non-atomic *and* atomic.

[file sink]: https://github.com/hashicorp/vault/blob/v1.21.4/command/agentproxyshared/sink/file/file_sink.go#L98-L103
[README.md]: https://github.com/fsnotify/fsnotify/blob/v1.9.0/README.md#watching-a-file-doesnt-work-well